### PR TITLE
Add support for .NET 3.5

### DIFF
--- a/WeakEvent/CompatibilityExtensions.cs
+++ b/WeakEvent/CompatibilityExtensions.cs
@@ -1,4 +1,4 @@
-#if !NETSTANDARD
+#if NET40 || NET35
 using System;
 using System.Reflection;
 

--- a/WeakEvent/NaiveConcurrentDictionary.cs
+++ b/WeakEvent/NaiveConcurrentDictionary.cs
@@ -1,0 +1,29 @@
+﻿#if NET35
+using System;
+using System.Collections.Generic;
+
+namespace WeakEvent
+{
+    internal class ConcurrentDictionary<TKey, TValue>
+    {
+        private readonly IDictionary<TKey, TValue> _inner;
+
+        public ConcurrentDictionary()
+        {
+            _inner = new Dictionary<TKey, TValue>();
+        }
+
+        public TValue GetOrAdd(TKey key, Func<TKey, TValue> valueFactory)
+        {
+            lock (_inner)
+            {
+                if (!_inner.TryGetValue(key, out var value))
+                {
+                    _inner[key] = value = valueFactory(key);
+                }
+                return value;
+            }
+        }
+    }
+}
+#endif

--- a/WeakEvent/WeakEvent.csproj
+++ b/WeakEvent/WeakEvent.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>netstandard1.1;net40;net45</TargetFrameworks>
+        <TargetFrameworks>netstandard1.1;net35;net40;net45</TargetFrameworks>
         <NeutralLanguage>en</NeutralLanguage>
         <FrameworkPathOverride Condition="'$(TargetFramework)' == 'net35'">$(MSBuildProgramFiles32)\Reference Assemblies\Microsoft\Framework\.NETFramework\v3.5\Profile\Client</FrameworkPathOverride>
     </PropertyGroup>
@@ -20,6 +20,14 @@
     <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard1.1'">
         <DefineConstants>$(DefineConstants);NETSTANDARD</DefineConstants>
     </PropertyGroup>
+
+    <PropertyGroup Condition="'$(TargetFramework)' == 'net35'">
+        <DefineConstants>$(DefineConstants);NET35</DefineConstants>
+    </PropertyGroup>
+
+    <ItemGroup Condition="'$(TargetFramework)' == 'net35'">
+        <PackageReference Include="TaskParallelLibrary" Version="1.0.2856" />
+    </ItemGroup>
 
     <PropertyGroup Condition="'$(TargetFramework)' == 'net40'">
         <DefineConstants>$(DefineConstants);NET40</DefineConstants>

--- a/WeakEvent/WeakEvent.csproj
+++ b/WeakEvent/WeakEvent.csproj
@@ -25,10 +25,6 @@
         <DefineConstants>$(DefineConstants);NET35</DefineConstants>
     </PropertyGroup>
 
-    <ItemGroup Condition="'$(TargetFramework)' == 'net35'">
-        <PackageReference Include="TaskParallelLibrary" Version="1.0.2856" />
-    </ItemGroup>
-
     <PropertyGroup Condition="'$(TargetFramework)' == 'net40'">
         <DefineConstants>$(DefineConstants);NET40</DefineConstants>
     </PropertyGroup>

--- a/WeakEvent/WeakEventSource.cs
+++ b/WeakEvent/WeakEventSource.cs
@@ -8,9 +8,7 @@ using System.Reflection;
 namespace WeakEvent
 {
     public class WeakEventSource<TEventArgs>
-#if NET40
         where TEventArgs : EventArgs
-#endif
     {
         private readonly List<WeakDelegate> _handlers;
 

--- a/WeakEvent/WeakEventSource.cs
+++ b/WeakEvent/WeakEventSource.cs
@@ -8,7 +8,9 @@ using System.Reflection;
 namespace WeakEvent
 {
     public class WeakEventSource<TEventArgs>
+#if NET40 || NET35
         where TEventArgs : EventArgs
+#endif
     {
         private readonly List<WeakDelegate> _handlers;
 

--- a/WeakEvent/WeakEventSource.cs
+++ b/WeakEvent/WeakEventSource.cs
@@ -1,9 +1,12 @@
 ﻿using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
+
+#if !NET35
+using System.Collections.Concurrent;
+#endif
 
 namespace WeakEvent
 {
@@ -57,7 +60,7 @@ namespace WeakEvent
 
         class WeakDelegate
         {
-            #region Open handler generation and cache
+#region Open handler generation and cache
 
             private delegate void OpenEventHandler(object target, object sender, TEventArgs e);
 
@@ -92,7 +95,7 @@ namespace WeakEvent
                 }
             }
 
-            #endregion
+#endregion
 
             private readonly WeakReference _weakTarget;
             private readonly MethodInfo _method;


### PR DESCRIPTION
I maintain https://github.com/ClosedXML/ClosedXML and we want to support .NET 3.5 for as long as possible. Yes, I know it's ancient, but getting it to build for .NET 3.5 isn't too much additional work. Just had to use a special package to mirror `ConcurrentDictionary`. 

