### PR TITLE
Ensure subscriptions can change while events are being raised

### DIFF
--- a/WeakEvent/WeakEventSource.cs
+++ b/WeakEvent/WeakEventSource.cs
@@ -25,8 +25,7 @@ namespace WeakEvent
             {
                 var failedHandlers = _handlers
                     .ToArray()
-                    .Where(h => !h.Invoke(sender, e))
-                    .ToArray();
+                    .Where(h => !h.Invoke(sender, e));
 
                 foreach (var h in failedHandlers)
                     _handlers.Remove(h);

--- a/WeakEvent/WeakEventSource.cs
+++ b/WeakEvent/WeakEventSource.cs
@@ -23,7 +23,13 @@ namespace WeakEvent
         {
             lock (_handlers)
             {
-                _handlers.RemoveAll(h => !h.Invoke(sender, e));
+                var failedHandlers = _handlers
+                    .ToArray()
+                    .Where(h => !h.Invoke(sender, e))
+                    .ToArray();
+
+                foreach (var h in failedHandlers)
+                    _handlers.Remove(h);
             }
         }
 


### PR DESCRIPTION
Ok, I'm assuming this package is supposed to be a kind of drop-in replacement for old-school event handlers with the purpose of making listeners garbage-collectable. If that's the case, this PR solves a small issue. 

When using normal events, it's possible to add or remove event subscriptions as part of the actions that are performed when the event fires. The newly added event handlers won't fire during that round, but only after subsequent times.

Currently, in `WeakEvent` new subscriptions will fire while enumerating through the handlers. 

This PR makes a small changes to copy the handlers to an array and fire them from there.

Let me know if you need unit tests.