### PR TITLE
Add unit test (and potential fix) for unclean handlers list

### DIFF
--- a/WeakEvent.Tests/WeakEventSourceTests.cs
+++ b/WeakEvent.Tests/WeakEventSourceTests.cs
@@ -199,6 +199,33 @@ namespace WeakEvent.Tests
             GC.KeepAlive(sub2);
         }
 
+        [Fact]
+        public void Can_Raise_Even_If_Delegates_List_Is_Unclean()
+        {
+            var pub = new Publisher();
+            
+            var sub1 = new InstanceSubscriber(1, i =>{});
+            sub1.Subscribe(pub);
+            var sub2 = new InstanceSubscriber(1, i =>{});
+            sub2.Subscribe(pub);
+            var sub3 = new InstanceSubscriber(1, i =>{});
+            sub3.Subscribe(pub);
+            var sub4 = new InstanceSubscriber(1, i =>{});
+            sub4.Subscribe(pub);
+            var sub5 = new InstanceSubscriber(1, i =>{});
+            sub5.Subscribe(pub);
+            var sub6 = new InstanceSubscriber(1, i =>{});
+            sub6.Subscribe(pub);
+            var sub7 = new InstanceSubscriber(1, i =>{});
+            sub7.Subscribe(pub);
+            var sub8 = new InstanceSubscriber(1, i =>{});
+            sub8.Subscribe(pub);
+
+            sub8.Unsubscribe(pub);
+
+            pub.Raise();
+        }
+
         #region Test subjects
 
         class Publisher

--- a/WeakEvent/WeakEventSource.cs
+++ b/WeakEvent/WeakEventSource.cs
@@ -30,10 +30,14 @@ namespace WeakEvent
                 int i = 0;
                 foreach (var weakHandler in weakHandlers)
                 {
-                    if (weakHandler.TryGetStrongHandler() is StrongHandler handler)
-                        validHandlers.Add(handler);
-                    else
-                        _handlers.Invalidate(i);
+                    if (weakHandler != null)
+                    {
+                        if (weakHandler.TryGetStrongHandler() is StrongHandler handler)
+                            validHandlers.Add(handler);
+                        else
+                            _handlers.Invalidate(i);
+                    }
+
                     i++;
                 }
 


### PR DESCRIPTION
The list of handlers can contain null entries. These null entries are only cleaned up if they are at least a quarter of the total list length.
Therefore, other sections of code must be able to handle the fact that there are null entries in the list.